### PR TITLE
fix/mutators reinitialize & api checks valid rsp

### DIFF
--- a/src/containers/Page1/Page.vue
+++ b/src/containers/Page1/Page.vue
@@ -94,14 +94,28 @@ export default {
 			for (var i = 0; i<res.data.length; i++) {
 				console.log(res.data[i])
 			}
-			var firstString = JSON.stringify(res.data.first_name[0])
-			var lastString = JSON.stringify(res.data.last_name[0])
-			var emailString = JSON.stringify(res.data.email_id[0])
-			console.log(emailString)
-			var addressString = JSON.stringify(res.data.office_address[0])
-			var phoneString = JSON.stringify(res.data.phone[0])
-			var stateString = JSON.stringify(res.data.state[0])
-			var titleString = JSON.stringify(res.data.title[0])
+			if (res.data.first_name) {
+				var firstString = JSON.stringify(res.data.first_name[0])
+			}
+			if (res.data.last_name) {
+				var lastString = JSON.stringify(res.data.last_name[0])
+			}
+			if (res.data.email_id) {
+				var emailString = JSON.stringify(res.data.email_id[0])
+			}
+			console.log('this is the emailString:' + emailString)
+			if (res.data.office_address) {
+				var addressString = JSON.stringify(res.data.office_address[0])
+			}
+			if (res.data.phone) {
+				var phoneString = JSON.stringify(res.data.phone[0])
+			}
+			if (res.data.state) {
+				var stateString = JSON.stringify(res.data.state[0])
+			}
+			if (res.data.title) {
+				var titleString = JSON.stringify(res.data.title[0])
+			}
 			this.$store.commit('updateFirst', firstString)
 			this.$store.commit('updateLast', lastString)
 			this.$store.commit('updateEmail', emailString)

--- a/src/store.js
+++ b/src/store.js
@@ -12,25 +12,32 @@ export const store = new Vuex.Store({
   },
 
   mutations: {
-    updateFirst(state, payload){  
+    updateFirst(state, payload){
+      state.data.first = ''  
       state.data.first = payload
     },
-    updateLast(state, payload){  
+    updateLast(state, payload){
+      state.data.last = ''  
       state.data.last = payload
     },
-    updateEmail(state, payload){  
+    updateEmail(state, payload){
+      state.data.email = ''  
       state.data.email = payload
     },
-    updateAddress(state, payload){  
+    updateAddress(state, payload){
+      state.data.address = ''  
       state.data.address = payload
     },
-    updatePhone(state, payload){  
+    updatePhone(state, payload){
+      state.data.phone = 0  
       state.data.phone = payload
     },
-    updateState(state, payload){  
+    updateState(state, payload){
+      state.data.state = ''  
       state.data.state = payload
     },
-    updateTitle(state, payload){  
+    updateTitle(state, payload){
+      state.data.title = ''  
       state.data.title = payload
     }
   }


### PR DESCRIPTION
Mutators now reinitialize themselves to blank before they re-update themselves meaning names should no longer display concatenated together in the front end. 
Also added validity checks to the API call to make sure valid data is received, and if it isn't in some cases it no longer produces an error. 